### PR TITLE
Reordering Example entrances (and maybe sorting them)

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -6,3 +6,18 @@ Code Examples
 .. contents:: Contents
    :local:
    :depth: 2
+
+bla bla 
+
+
+.. toctree::
+    :maxdepth: 1
+
+    io/README.txt
+    preprocessing/README.txt
+    visualization/README.txt
+
+
+    connectivity/README.txt
+
+    


### PR DESCRIPTION
that was my attempt to reorder the way the examples appear. But I don't seem to manage to make it work. Is it because we are using the `README.txt` as an entry point and we should be using `index.rst` in which case we have more control of what we make appear? 

plus, if we want to reorder the examples how shall we do it? I've seen couple issues and PRs by @larsoner (like this https://github.com/sphinx-gallery/sphinx-gallery/issues/275) but I couldn't figure it out based on [this doc](https://sphinx-gallery.readthedocs.io/en/latest/configuration.html#sorting-gallery-examples)

can someone give us a hand?