### PR TITLE
Fix the function to extract last 32bits from number

### DIFF
--- a/mne/io/cnt/_utils.py
+++ b/mne/io/cnt/_utils.py
@@ -155,7 +155,6 @@ def _compute_robust_event_table_position(fid):
 
     fid.seek(SETUP_EVENTTABLEPOS_OFFSET)
     (event_table_pos,) = np.frombuffer(fid.read(4), dtype='<i4')
-    fid.seek(SETUP_EVENTTABLEPOS_OFFSET)
 
     n_bytes, event_table_pos = _infer_n_bytes_event_table_pos(event_table_pos)
 

--- a/mne/io/cnt/cnt.py
+++ b/mne/io/cnt/cnt.py
@@ -17,7 +17,6 @@ from ..meas_info import _empty_info
 from ..base import BaseRaw
 from ...annotations import Annotations
 
-
 from ._utils import (_read_teeg, _get_event_parser, _session_date_2_meas_date,
                      _compute_robust_event_table_position, CNTEventType3)
 
@@ -57,7 +56,7 @@ def _read_annotations_cnt(fname, data_format='to deprecate?'):
         (sfreq,) = np.frombuffer(fid.read(2), dtype='<u2')
 
         n_channels, n_samples, event_table_pos, n_bytes = (
-            _compute_robust_event_table_position(fid))
+            _compute_robust_event_table_position(fid, data_format))
 
     with open(fname, 'rb') as fid:
         teeg = _read_teeg(fid, teeg_offset=event_table_pos)
@@ -224,7 +223,7 @@ def _get_cnt_info(input_fname, eog, ecg, emg, misc, data_format, date_format,
                                                      count=1)[0]
 
         n_channels, n_samples, event_offset, n_bytes = (
-            _compute_robust_event_table_position(fid))
+            _compute_robust_event_table_position(fid, data_format))
 
         # Channel offset refers to the size of blocks per channel in the file.
         cnt_info['channel_offset'] = np.fromfile(fid, dtype='<i4', count=1)[0]


### PR DESCRIPTION
In previous version, the way to obtain the last 32 bits of the event_table_pos is in fact wrong, which is fix in this PR. 

As for the file mentioned in the Issue [#6550](https://github.com/mne-tools/mne-python/pull/6550), named **914flankers.cnt**, is in fact a special file which has no overflow problem, but the calculated event table pos and the readed version from SETUP section just unmatch. That means reading this file will still throw an exception. One possible reason is there is the number of samples is not correct, and I will give another PR to fix this problem (one simple solution is not to throw an exception, but return the readed value)

Before that, I have test all the cnt file in my hand, if possible, could try the new version on your dataset agian?
